### PR TITLE
Return access token from get_token by default, continue to save token…

### DIFF
--- a/man/get_token.Rd
+++ b/man/get_token.Rd
@@ -4,15 +4,22 @@
 \alias{get_token}
 \title{Get Access Token}
 \usage{
-get_token(uid, secret)
+get_token(uid, secret, use_environment = TRUE)
 }
 \arguments{
 \item{-}{uid: Consumer key associated with the user's aWhere API account}
 
 \item{-}{secret: Consumer secret associated the user's aWhere API account}
+
+\item{-}{use_enviroment: Optional logical value, determines whether API access
+token will be saved in a local locked environment in addition to being returned
+by the function.}
 }
 \value{
-None
+List with three elements:
+error: logical indicating whether there was an error
+error_message: \code{NULL} if error is \code{FALSE}, a character error message otherwise
+token: aWhere API access token value
 }
 \description{
 \code{get_token} gets Access Token for V2 aWhere API
@@ -23,5 +30,5 @@ function can be found on a user's account at developer.awhere.com, under the app
 }
 \examples{
 \dontrun{get_token("uid", "secret")}
+\dontrun{token_response <- get_token('uid', 'secret', use_environment = FALSE)}
 }
-


### PR DESCRIPTION
… in environment by default but allow user to skip if desired.

This avoids crashing on a non-200 status code, and allows checking token refresh requests without needing the previous token value for comparison.

Also, returning a list with error status, error message, and token value in all cases allows for more consistent handling of the response.