### PR TITLE
Fix check_JSON list return error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aWhereAPI
 Title: API calls for aWhere API
-Version: 0.5.17
+Version: 0.5.18
 Authors@R: 
     c(person("Technical", "Support", ,"technicalsupport@awhere.com", role = c("aut","cre","ctb")))
 Description: 

--- a/R/get-token.R
+++ b/R/get-token.R
@@ -149,7 +149,7 @@ check_JSON <- function(jsonObject
     #Non enterprise accounts are allowed to return 10 days of data at a time
     #FALSE is returned because the logic of the API call will need to be
     #adjusted due to the changed limit paramater
-    return(list(FALSE,10))
+    return(list(FALSE,10,tokenToUse))
   }
 
   #Parses JSON to see if it tells us that we need a new token
@@ -160,7 +160,7 @@ check_JSON <- function(jsonObject
         tokenToUse <- awhereEnv75247$token
 
         #This boolean will cause the API request to be repeated
-        return(list(TRUE,NA))
+        return(list(TRUE,NA,tokenToUse))
       } else {
         stop("The token you passed in has expired. Please request a new one and retry your function call with the new token.")
       }

--- a/R/weather-daily.R
+++ b/R/weather-daily.R
@@ -149,7 +149,9 @@ daily_observed_fields <- function(field_id
         doWeatherGet <- temp[[1]]
         
         #if the token was updated, this will cause it to be used through function
-        tokenToUse <- temp[[3]]
+        if(length(temp) > 2) {
+          tokenToUse <- temp[[3]]
+        }
         
         #The temp[[2]] will only not be NA when the limit param is too large.
         if(!is.na(temp[[2]] == TRUE)) {
@@ -347,7 +349,9 @@ daily_observed_latlng <- function(latitude
         doWeatherGet <- temp[[1]]
         
         #if the token was updated, this will cause it to be used through function
-        tokenToUse <- temp[[3]]
+        if(length(temp) > 2) {
+          tokenToUse <- temp[[3]]
+        }
         
         #The temp[[2]] will only not be NA when the limit param is too large.
         if(!is.na(temp[[2]] == TRUE)) {

--- a/R/weather-daily.R
+++ b/R/weather-daily.R
@@ -149,9 +149,7 @@ daily_observed_fields <- function(field_id
         doWeatherGet <- temp[[1]]
         
         #if the token was updated, this will cause it to be used through function
-        if(length(temp) > 2) {
-          tokenToUse <- temp[[3]]
-        }
+        tokenToUse <- temp[[3]]
         
         #The temp[[2]] will only not be NA when the limit param is too large.
         if(!is.na(temp[[2]] == TRUE)) {
@@ -349,9 +347,7 @@ daily_observed_latlng <- function(latitude
         doWeatherGet <- temp[[1]]
         
         #if the token was updated, this will cause it to be used through function
-        if(length(temp) > 2) {
-          tokenToUse <- temp[[3]]
-        }
+        tokenToUse <- temp[[3]]
         
         #The temp[[2]] will only not be NA when the limit param is too large.
         if(!is.na(temp[[2]] == TRUE)) {


### PR DESCRIPTION
All the API functions that reference the check_JSON function attempt to assign the 3rd object in the list returned from this function to the tokenToUse variable. However there was no 3rd object being returned when limit parameter was tripped for non-enterprise accounts nor when the API access had expired and the function automatically requested a new token