### PR TITLE
Fixed forecast date adjustment bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aWhereAPI
 Title: API calls for aWhere API
-Version: 0.5.21
+Version: 0.5.22
 Authors@R: 
     c(person("Technical", "Support", ,"technicalsupport@awhere.com", role = c("aut","cre","ctb")))
 Description: 

--- a/R/forecasts.R
+++ b/R/forecasts.R
@@ -89,7 +89,10 @@ forecasts_fields <- function(field_id
     } 
     
     if (day_end != '') {
-      if (day_end == Sys.Date() + 15) {
+      if (day_end == Sys.Date()) {
+        cat(paste0('Adjusted the endDate of query to one day later because the location data being requested for has a different date\n'))
+        day_end <- as.character(lubridate::ymd(day_end) + 1)
+      } else if (day_end == Sys.Date() + 15) {
         cat(paste0('Adjusted the endDate of query to one day earlier because the location data being requested for has a different date\n'))
         day_end <- as.character(lubridate::ymd(day_end) - 1)
       }
@@ -257,7 +260,10 @@ forecasts_latlng <- function(latitude
     } 
     
     if (day_end != '') {
-      if (day_end == Sys.Date() + 15) {
+      if (day_end == Sys.Date()) {
+        cat(paste0('Adjusted the endDate of query to one day later because the location data being requested for has a different date\n'))
+        day_end <- as.character(lubridate::ymd(day_end) + 1)
+      } else if (day_end == Sys.Date() + 15) {
         cat(paste0('Adjusted the endDate of query to one day earlier because the location data being requested for has a different date\n'))
         day_end <- as.character(lubridate::ymd(day_end) - 1)
       }


### PR DESCRIPTION
Previously when the start and end dates were both equal to the system date and therefore time zone adjustment occurred, only the start date would be adjusted forwards a day. This creates an issue where the start date is later than the end date. I added the code to also increment the end date