### PR TITLE
 Updated R package to be able to use different versions of the API

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aWhereAPI
 Title: API calls for aWhere API
-Version: 0.5.24
+Version: 0.6.01
 Authors@R: 
     c(person("Technical", "Support", ,"technicalsupport@awhere.com", role = c("aut","cre","ctb")))
 Description: 

--- a/R/agronomic-crops.R
+++ b/R/agronomic-crops.R
@@ -41,7 +41,7 @@ get_crops <- function(crop_id = ''
   checkCredentials(keyToUse,secretToUse,tokenToUse)
   
   ## Create Request
-  url <- "https://api.awhere.com/v2/agronomics/crops/"
+  url <- paste0(awhereEnv75247$apiAddress, "/agronomics/crops/")
   
   if(crop_id != "") {
     url <- paste0(url, crop_id)

--- a/R/agronomic-norms.R
+++ b/R/agronomic-norms.R
@@ -189,7 +189,7 @@ agronomic_norms_fields <- function(field_id
       ##############################################################################
 
       # Create query
-      urlAddress <- "https://api.awhere.com/v2/agronomics"
+      urlAddress <- paste0(awhereEnv75247$apiAddress, "/agronomics")
 
       strBeg <- paste0('/fields')
       strCoord <- paste0('/',field_id)
@@ -527,7 +527,7 @@ agronomic_norms_latlng <- function(latitude
       ##############################################################################
 
       # Create query
-      urlAddress <- "https://api.awhere.com/v2/agronomics"
+      urlAddress <- paste0(awhereEnv75247$apiAddress, "/agronomics")
 
       strBeg <- paste0('/locations')
       strCoord <- paste0('/',latitude,',',longitude)

--- a/R/agronomic-values.R
+++ b/R/agronomic-values.R
@@ -131,7 +131,7 @@ agronomic_values_fields <- function(field_id
       }
 
       # Create query
-      urlAddress <- "https://api.awhere.com/v2/agronomics"
+      urlAddress <- paste0(awhereEnv75247$apiAddress, "/agronomics")
 
       strBeg <- paste0('/fields')
       strCoord <- paste0('/',field_id)
@@ -389,7 +389,7 @@ agronomic_values_latlng <- function(latitude
       }
 
       # Create query
-      urlAddress <- "https://api.awhere.com/v2/agronomics"
+      urlAddress <- paste0(awhereEnv75247$apiAddress, "/agronomics")
 
       strBeg <- paste0('/locations')
       strCoord <- paste0('/',latitude,',',longitude)

--- a/R/create.R
+++ b/R/create.R
@@ -67,7 +67,7 @@ create_field <- function(field_id
   farm_id <- gsub(' ','_',farm_id)
 
   ## Create Request
-  url <- "https://api.awhere.com/v2/fields"
+  url <- paste0(awhereEnv75247$apiAddress, "/fields")
 
   postbody <- paste0('{"id":"', field_id, '",',
                      '"centerPoint":{"latitude":', latitude, ',"longitude":', longitude, '}',
@@ -188,7 +188,7 @@ create_planting <- function(field_id
 
   checkValidField(field_id,keyToUse,secretToUse,tokenToUse)
 
-  url <- paste0("https://api.awhere.com/v2/agronomics/fields/", field_id, "/plantings")
+  url <- paste0(awhereEnv75247$apiAddress, "/agronomics/fields/", field_id, "/plantings")
 
   postbody <- paste0('{',
                      '"crop":"', crop, '",',
@@ -303,7 +303,7 @@ create_job <- function(api_requests
   job_title <- gsub(' ','_', job_title)
 
   ## Create Request
-  url <- "https://api.awhere.com/v2/jobs"
+  url <- paste0(awhereEnv75247$apiAddress, "/jobs")
 
   requests <- data.frame(title=request_titles, api=api_requests)
   postbody <- jsonlite::toJSON(list(title=job_title, type=job_type,

--- a/R/current-conditions.R
+++ b/R/current-conditions.R
@@ -50,7 +50,7 @@ current_conditions_fields <- function(field_id
 
   # Create query
 
-  urlAddress <- "https://api.awhere.com/v2/weather"
+  urlAddress <- paste0(awhereEnv75247$apiAddress, "/weather")
 
   strBeg <- paste0('/fields')
   strCoord <- paste0('/',field_id)
@@ -146,7 +146,7 @@ current_conditions_latlng <- function(latitude
 
   # Create query
 
-  urlAddress <- "https://api.awhere.com/v2/weather"
+  urlAddress <- paste0(awhereEnv75247$apiAddress, "/weather")
 
   strBeg <- paste0('/locations')
   strCoord <- paste0('/',latitude,',',longitude)

--- a/R/delete.R
+++ b/R/delete.R
@@ -31,7 +31,7 @@ delete_field <- function(field_id
   checkCredentials(keyToUse,secretToUse,tokenToUse)
   checkValidField(field_id,keyToUse,secretToUse,tokenToUse)
 
-  url <- paste0("https://api.awhere.com/v2/fields/", field_id)
+  url <- paste0(awhereEnv75247$apiAddress, "/fields/", field_id)
 
   postbody <- paste0('{', field_id, '}');
 
@@ -96,7 +96,7 @@ delete_planting <- function(field_id
   checkCredentials(keyToUse,secretToUse,tokenToUse)
   checkValidField(field_id,keyToUse,secretToUse,tokenToUse)
 
-  url <- paste0("https://api.awhere.com/v2/agronomics/fields/", field_id,'/plantings/',planting_id)
+  url <- paste0(awhereEnv75247$apiAddress, "/agronomics/fields/", field_id,'/plantings/',planting_id)
 
   doWeatherGet = TRUE
   while (doWeatherGet == TRUE) {

--- a/R/forecasts.R
+++ b/R/forecasts.R
@@ -71,7 +71,7 @@ forecasts_fields <- function(field_id
   #checkValidStartEndDatesForecast(day_start,day_end)
   checkForecastParams(block_size)
 
-  fieldInfo <- get_fields('field_id')
+  fieldInfo <- get_fields(field_id)
   
   #Checks if dates need to be adjusted.  This only applies when someone is request
   tz_request <- lutz::tz_lookup_coords(fieldInfo$Latitude

--- a/R/forecasts.R
+++ b/R/forecasts.R
@@ -100,7 +100,7 @@ forecasts_fields <- function(field_id
   }
   
   #Create Query
-  urlAddress <- "https://api.awhere.com/v2/weather"
+  urlAddress <- paste0(awhereEnv75247$apiAddress, "/weather")
 
   strBeg <- paste0('/fields')
   strCoord <- paste0('/',field_id)
@@ -272,7 +272,7 @@ forecasts_latlng <- function(latitude
   
   
   #Create Query
-  urlAddress <- "https://api.awhere.com/v2/weather"
+  urlAddress <- paste0(awhereEnv75247$apiAddress, "/weather")
 
   strBeg <- paste0('/locations')
   strCoord <- paste0('/',latitude,',',longitude)

--- a/R/get-token.R
+++ b/R/get-token.R
@@ -23,30 +23,30 @@
 #' \dontrun{token_response <- get_token('uid', 'secret', use_environment = FALSE)}
 #' @export
 
-get_token <- function(uid, secret, use_environment = TRUE) {
-
-  url <- "https://api.awhere.com/oauth/token"
-
+get_token <- function(uid, secret, use_environment = TRUE, apiAddress = "api.awhere.com") {
+  
+  url <- paste0("https://", apiAddress, "/oauth/token")
+  
   authen_char <- charToRaw(paste0(uid,':',secret))
-
+  
   request <- httr::POST(url, body='grant_type=client_credentials',
                         httr::content_type('application/x-www-form-urlencoded'),
                         httr::add_headers(Authorization = paste0('Basic ', base64enc::base64encode(authen_char))))
-
+  
   a <- suppressMessages(httr::content(request, as = "text"))
-
+  
   if (request$status_code != 200) {
     error <- TRUE
     error_message <- 'The UID/Secret combination is incorrect.'
     token <- NULL
-
+    
     cat(paste(error_message, '\n'))
   } else {
     error <- FALSE
     error_message <- NULL
-
+    
     parsedResponse <- jsonlite::fromJSON(a, simplifyDataFrame = FALSE)
-
+    
     # Keeping environment approach for backward compatibility,
     # but adding an optional argument to skip it.
     if (use_environment) {
@@ -55,7 +55,7 @@ get_token <- function(uid, secret, use_environment = TRUE) {
         assign('awhereEnv75247',awhereEnv75247,envir = baseenv())
         rm(awhereEnv75247)
       }
-
+      
       if (exists('uid',envir = awhereEnv75247,inherits = FALSE) == TRUE) {
         if (bindingIsLocked('uid',awhereEnv75247) == TRUE) {
           unlockBinding('uid',awhereEnv75247)
@@ -71,20 +71,27 @@ get_token <- function(uid, secret, use_environment = TRUE) {
           unlockBinding('token',awhereEnv75247)
         }
       }
-
+      if (exists('apiAddress',where = awhereEnv75247,inherits = FALSE) == TRUE) {
+        if (bindingIsLocked('apiAddress',awhereEnv75247) == TRUE) {
+          unlockBinding('apiAddress',awhereEnv75247)
+        }
+      }
+      
       awhereEnv75247$uid    <- uid
       awhereEnv75247$secret <- secret
       awhereEnv75247$token  <- token <- parsedResponse$access_token
-
+      awhereEnv75247$apiAddress <- paste0("https://", apiAddress, "/v2")
+      
       lockBinding('uid',    awhereEnv75247)
       lockBinding('secret', awhereEnv75247)
       lockBinding('token',  awhereEnv75247)
-
+      lockBinding('apiAddress', awhereEnv75247)
+      
       lockEnvironment(awhereEnv75247,bindings = TRUE)
       rm(awhereEnv75247)
     }
   }
-
+  
   return(list(error = error
               ,error_message = error_message
               ,token = token))
@@ -114,10 +121,10 @@ get_token <- function(uid, secret, use_environment = TRUE) {
 
 load_credentials <- function(path_to_credentials) {
   credentials <- readLines(path_to_credentials)
-
+  
   uid <- credentials[1]
   secret <- credentials[2]
-
+  
   get_token(uid, secret)
 }
 
@@ -142,23 +149,23 @@ check_JSON <- function(jsonObject
                        ,keyToUse 
                        ,secretToUse 
                        ,tokenToUse) {
-
+  
   #Parses JSON to see if tells us we made too large of a request
   if (any(grepl('The maximum value for the limit parameter is',jsonObject))) {
-
+    
     #Non enterprise accounts are allowed to return 10 days of data at a time
     #FALSE is returned because the logic of the API call will need to be
     #adjusted due to the changed limit paramater
     return(list(FALSE,10,tokenToUse))
   }
-
+  
   #Parses JSON to see if it tells us that we need a new token
   if (any(grepl('API Access Expired',jsonObject))) {
     if(exists("awhereEnv75247")) {
       if(tokenToUse == awhereEnv75247$token) {
         get_token(keyToUse,secretToUse)
         tokenToUse <- awhereEnv75247$token
-
+        
         #This boolean will cause the API request to be repeated
         return(list(TRUE,NA,tokenToUse))
       } else {
@@ -168,10 +175,10 @@ check_JSON <- function(jsonObject
       stop("The token you passed in has expired. Please request a new one and retry your function call with the new token.")
     }
   }
-
+  
   #Finally check to see if there was a different problem with the query and if so return the message
   checkStatusCode(request)
-
+  
   return(list(FALSE,NA,tokenToUse))
 }
 

--- a/R/get-token.R
+++ b/R/get-token.R
@@ -94,7 +94,8 @@ get_token <- function(uid, secret, use_environment = TRUE, apiAddress = "api.awh
   
   return(list(error = error
               ,error_message = error_message
-              ,token = token))
+              ,token = token
+              ,apiAddress = apiAddress))
 }
 
 #' @title Load Credentials.
@@ -119,13 +120,15 @@ get_token <- function(uid, secret, use_environment = TRUE, apiAddress = "api.awh
 #'
 #' @export
 
-load_credentials <- function(path_to_credentials) {
+load_credentials <- function(path_to_credentials,apiAddress = "api.awhere.com") {
   credentials <- readLines(path_to_credentials)
   
   uid <- credentials[1]
   secret <- credentials[2]
   
-  get_token(uid, secret)
+  get_token(uid = uid
+            ,secret = secret
+            ,apiAddress = apiAddress)
 }
 
 #' @title Check JSON Object
@@ -163,7 +166,9 @@ check_JSON <- function(jsonObject
   if (any(grepl('API Access Expired',jsonObject))) {
     if(exists("awhereEnv75247")) {
       if(tokenToUse == awhereEnv75247$token) {
-        get_token(keyToUse,secretToUse)
+        get_token(uid = keyToUse
+                  ,secret = secretToUse
+                  ,apiAddress = awhereEnv75247$apiAddress)
         tokenToUse <- awhereEnv75247$token
         
         #This boolean will cause the API request to be repeated

--- a/R/get.R
+++ b/R/get.R
@@ -54,7 +54,7 @@ get_fields <- function(field_id = ""
   }
   
   ## Create Request
-  url <- "https://api.awhere.com/v2/fields/"
+  url <- paste0(awhereEnv75247$apiAddress, "/fields/")
 
   if(field_id != "") {
     url <- paste0(url, field_id)
@@ -217,7 +217,7 @@ get_planting <- function(field_id = ""
   }
   
   ## Create Request
-  url <- "https://api.awhere.com/v2/agronomics/"
+  url <- paste0(awhereEnv75247$apiAddress, "/agronomics/")
 
   if(field_id != "") {
     checkValidField(field_id,keyToUse,secretToUse,tokenToUse)
@@ -396,7 +396,7 @@ get_job <- function(job_id
   checkCredentials(keyToUse,secretToUse,tokenToUse)
 
   ## Create Request
-  url <- "https://api.awhere.com/v2/jobs/"
+  url <- paste0(awhereEnv75247$apiAddress, "/jobs/")
 
   if(is.na(job_id)) {
     stop("must specify job_id")

--- a/R/models.R
+++ b/R/models.R
@@ -136,6 +136,7 @@ get_model_details <- function(model_id
   
   ## Create Request
   url <- paste0(awhereEnv75247$apiAddress, "/agronomics/models/")
+  
   url <- paste0(url, model_id, "/details")
   
   

--- a/R/models.R
+++ b/R/models.R
@@ -38,7 +38,7 @@ get_models <- function(model_id = ''
   checkCredentials(keyToUse,secretToUse,tokenToUse)
   
   ## Create Request
-  url <- "https://api.awhere.com/v2/agronomics/models/"
+  url <- paste0(awhereEnv75247$apiAddress, "/agronomics/models/")
   
   if(model_id != "") {
     url <- paste0(url, model_id)
@@ -135,7 +135,7 @@ get_model_details <- function(model_id
   checkCredentials(keyToUse,secretToUse,tokenToUse)
   
   ## Create Request
-  url <- "https://api.awhere.com/v2/agronomics/models/"
+  url <- paste0(awhereEnv75247$apiAddress, "/agronomics/models/")
   
   url <- paste0(url, model_id, "/details")
   
@@ -229,7 +229,7 @@ get_model_results <- function(field_id
   checkCredentials(keyToUse,secretToUse,tokenToUse)
   
   ## Create Request
-  url <- "https://api.awhere.com/v2/agronomics/fields/"
+  url <- paste0(awhereEnv75247$apiAddress, "/agronomics/fields/")
   
   url <- paste0(url, field_id, "/models/", model_id, "/results")
   

--- a/R/update.R
+++ b/R/update.R
@@ -45,7 +45,7 @@ update_field <- function(field_id
   checkValidField(field_id,keyToUse,secretToUse,tokenToUse)
 
   ## Creating the request
-  url <- paste0("https://api.awhere.com/v2/fields/",field_id)
+  url <- paste0(awhereEnv75247$apiAddress, "/fields/",field_id)
 
   postbody <- paste0('[{"op":"replace","path":"/', variable_update, '","value":"', value_update, '"}]')
 
@@ -197,7 +197,7 @@ update_planting <- function(field_id
 
   ## Creating the request
 
-  url <- paste0("https://api.awhere.com/v2/agronomics/fields/", field_id, "/plantings/")
+  url <- paste0(awhereEnv75247$apiAddress, "/agronomics/fields/", field_id, "/plantings/")
 
   if(planting_id == "") {
     url <- paste0(url, "current")

--- a/R/weather-daily.R
+++ b/R/weather-daily.R
@@ -108,7 +108,7 @@ daily_observed_fields <- function(field_id
       
       # Create query
       
-      urlAddress <- "https://api.awhere.com/v2/weather"
+      urlAddress <- paste0(awhereEnv75247$apiAddress, "/weather")
       
       strBeg <- paste0('/fields')
       strCoord <- paste0('/',field_id)
@@ -303,7 +303,7 @@ daily_observed_latlng <- function(latitude
       
       
       # Create query
-      urlAddress <- "https://api.awhere.com/v2/weather"
+      urlAddress <- paste0(awhereEnv75247$apiAddress, "/weather")
       
       strBeg <- paste0('/locations')
       strCoord <- paste0('/',latitude,',',longitude)

--- a/R/weather-norms.R
+++ b/R/weather-norms.R
@@ -154,7 +154,7 @@ weather_norms_fields <- function(field_id
 
       # Create query
 
-      urlAddress <- "https://api.awhere.com/v2/weather"
+      urlAddress <- paste0(awhereEnv75247$apiAddress, "/weather")
 
       strBeg <- paste0('/fields')
       strCoord <- paste0('/',field_id)
@@ -419,7 +419,7 @@ weather_norms_latlng <- function(latitude
 
       # Create query
 
-      urlAddress <- "https://api.awhere.com/v2/weather"
+      urlAddress <- paste0(awhereEnv75247$apiAddress, "/weather")
 
       strBeg <- paste0('/locations')
       strCoord <- paste0('/',latitude,',',longitude)


### PR DESCRIPTION
Made code changes to allow user to specify which api address they want to use. By default set to the production one, but if the user knows the other addresses, then they can explicitly set the new `apiAddress` function parameter in the `get_token` function.

Also fixed a small bug in the forecasts fields function where it incorrectly had the field_id parameter quoted which was causing an issue when trying to look up the field's information.